### PR TITLE
Add setForced(true) to checkout.

### DIFF
--- a/confluence-plugin/pom.xml
+++ b/confluence-plugin/pom.xml
@@ -142,19 +142,19 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>4.9.1.201712030800-r</version>
+            <version>5.7.0.202003110725-r</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit.http.server</artifactId>
-            <version>4.9.1.201712030800-r</version>
+            <version>5.7.0.202003110725-r</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit.junit.http</artifactId>
-            <version>4.9.1.201712030800-r</version>
+            <version>5.7.0.202003110725-r</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>

--- a/confluence-plugin/src/main/java/com/networkedassets/git4c/infrastructure/git/DefaultGitClient.kt
+++ b/confluence-plugin/src/main/java/com/networkedassets/git4c/infrastructure/git/DefaultGitClient.kt
@@ -348,7 +348,7 @@ class DefaultGitClient() : GitClient {
             }
         }
 
-        git.checkout().setName("refs/heads/$trueBranch").call()
+        git.checkout().setName("refs/heads/$trueBranch").setForced(true).call()
         log.debug { "Changing of a branch has been done for ${dir}" }
         return git
     }


### PR DESCRIPTION
It will make the checkout more reliable as it will ignore working directory modifications.
Works around https://bugs.eclipse.org/bugs/show_bug.cgi?id=561341 .