### PR TITLE
plantuml-mit-update-to-1.2020.11

### DIFF
--- a/confluence-plugin/pom.xml
+++ b/confluence-plugin/pom.xml
@@ -239,7 +239,7 @@
         <dependency>
             <groupId>net.sourceforge.plantuml</groupId>
             <artifactId>plantuml-mit</artifactId>
-            <version>1.2017.15</version>
+            <version>1.2020.11</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/confluence-plugin/pom.xml
+++ b/confluence-plugin/pom.xml
@@ -445,7 +445,7 @@
                 <configuration>
                     <groupId>net.sourceforge.plantuml</groupId>
                     <artifactId>plantuml-mit</artifactId>
-                    <version>1.2017.15</version>
+                    <version>1.2020.11</version>
                     <packaging>jar</packaging>
                     <file>${basedir}/lib/plantuml.jar</file>
                     <generatePom>true</generatePom>


### PR DESCRIPTION
Update plantuml-mit lib to version 1.2020.11 to resolve isses with static image rendering for some advanced *UMLs