### PR TITLE
jgit-update-5.8.0.202006091008-r

### DIFF
--- a/confluence-plugin/pom.xml
+++ b/confluence-plugin/pom.xml
@@ -142,19 +142,25 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>5.3.0.201903130848-r</version>
+            <version>5.8.0.202006091008-r</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
+            <version>5.8.0.202006091008-r</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit.http.server</artifactId>
-            <version>5.3.0.201903130848-r</version>
+            <version>5.8.0.202006091008-r</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit.junit.http</artifactId>
-            <version>5.3.0.201903130848-r</version>
+            <version>5.8.0.202006091008-r</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <atlassian.spring.scanner.version>1.2.6</atlassian.spring.scanner.version>
         <!-- This key is used to keep the consistency between the key in atlassian-plugin.xml and the key to generate bundle. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
-        <amps.version>6.3.1</amps.version>
+        <amps.version>6.3.19</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
         <kotlin.version>1.1.60</kotlin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,14 @@
             <name>public</name>
             <url>https://repo.maven.apache.org/maven2</url>
         </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>jgit</id>
+            <name>Eclipse jGit</name>
+            <url>https://repo.eclipse.org/content/repositories/jgit-releases/</url>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
Update jGit to 5.8.0.202006091008-r to resolve broken repo checkouts and EOL issues in files.